### PR TITLE
Improve path and filename management

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -117,7 +117,7 @@ class FileBrowserIconView(IconView):
         super(FileBrowserIconView,self).open_entry(entry)
 
         # Remove appended '../' strings
-        if(entry.path == u'..' + sep):
+        if(platform == 'win' and entry.path == u'..' + sep):
           self.path = sep.join(self.path.split(sep)[:-3]) + sep
         else:
           self.path = self.path + sep
@@ -127,7 +127,7 @@ class FileBrowserListView(ListView):
         super(FileBrowserListView,self).open_entry(entry)
 
         # Remove appended '../' strings
-        if(entry.path == u'..' + sep):
+        if(platform == 'win' and entry.path == u'..' + sep):
           self.path = sep.join(self.path.split(sep)[:-3]) + sep
         else:
           self.path = self.path + sep
@@ -175,7 +175,7 @@ Builder.load_string('''
                 height: '22dp'
                 text_size: self.size
                 padding_x: '-10dp'
-                text: '' if len(root.path) < 2 else (root.path if root.path[-2] == ':' else root.path[:-1])
+                text: root.path if len(root.path) < 2 else (root.path if root.path[-2] == ':' else root.path[:-1])
                 valign: 'middle'
             TabbedPanel:
                 id: tabbed_browser

--- a/__init__.py
+++ b/__init__.py
@@ -62,6 +62,7 @@ __version__ = '1.1-dev'
 from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.treeview import TreeViewLabel, TreeView
 from kivy.uix.filechooser import FileChooserIconView as IconView
+from kivy.uix.filechooser import FileChooserListView as ListView
 try:
     from kivy.garden.filechooserthumbview import FileChooserThumbView as\
     IconView
@@ -112,7 +113,20 @@ def get_drives():
     return drives
 
 class FileBrowserIconView(IconView):
-    pass
+    def open_entry(self, entry):
+        super(FileBrowserIconView,self).open_entry(entry)
+
+        # Remove appended '../' strings
+        if(entry.path == u'..' + sep):
+          self.path = sep.join(self.path.split(sep)[:-3]) + sep
+
+class FileBrowserListView(ListView):
+    def open_entry(self, entry):
+        super(FileBrowserListView,self).open_entry(entry)
+
+        # Remove appended '../' strings
+        if(entry.path == u'..' + sep):
+          self.path = sep.join(self.path.split(sep)[:-3]) + sep
 
 Builder.load_string('''
 #:kivy 1.2.0
@@ -164,7 +178,7 @@ Builder.load_string('''
                 do_default_tab: False
                 TabbedPanelItem:
                     text: 'List View'
-                    FileChooserListView:
+                    FileBrowserListView:
                         id: list_view
                         path: root.path
                         filters: root.filters

--- a/__init__.py
+++ b/__init__.py
@@ -17,7 +17,7 @@ To create a FileBrowser which prints the currently selected file as well as
 the current text in the filename field when 'Select' is pressed, with
 a shortcut to the Documents directory added to the favorites bar::
 
-    ffrom kivy.app import App
+    from kivy.app import App
     from os.path import sep, expanduser, isdir, dirname
 
     class TestApp(App):
@@ -35,10 +35,10 @@ a shortcut to the Documents directory added to the favorites bar::
             return browser
 
         def _fbrowser_canceled(self, instance):
-            print 'cancelled, Close self.'
+            print('cancelled, Close self.')
 
         def _fbrowser_success(self, instance):
-            print instance.selection
+            print(instance.selection)
 
     TestApp().run()
 
@@ -73,7 +73,7 @@ from kivy.lang import Builder
 from kivy.utils import platform
 from kivy.clock import Clock
 import string
-from os.path import sep, dirname, expanduser, isdir
+from os.path import sep, dirname, expanduser, isdir, basename
 from os import walk
 from functools import partial
 
@@ -196,8 +196,7 @@ Builder.load_string('''
         spacing: [5]
         TextInput:
             id: file_text
-            text: (root.selection and (root._shorten_filenames(\
-            root.selection) if root.multiselect else root.selection[0])) or ''
+            text: (root.selection and (root._shorten_filenames(root.selection))) or ''
             hint_text: 'Filename'
             multiline: False
         Button:
@@ -495,11 +494,11 @@ class FileBrowser(BoxLayout):
         if not len(filenames):
             return ''
         elif len(filenames) == 1:
-            return filenames[0]
+            return basename(filenames[0])
         elif len(filenames) == 2:
-            return filenames[0] + ', ' + filenames[1]
+            return basename(filenames[0]) + ', ' + basename(filenames[1])
         else:
-            return filenames[0] + ', _..._, ' + filenames[-1]
+            return basename(filenames[0]) + ', _..._, ' + basename(filenames[-1])
 
     def _attr_callback(self, attr, obj, value):
         setattr(self, attr, getattr(obj, attr))

--- a/__init__.py
+++ b/__init__.py
@@ -74,7 +74,7 @@ from kivy.utils import platform
 from kivy.clock import Clock
 import string
 from os.path import sep, dirname, expanduser, isdir, basename
-from os import walk
+from os import walk, getcwd
 from functools import partial
 
 if platform == 'win':
@@ -117,7 +117,6 @@ class FileBrowserIconView(IconView):
 Builder.load_string('''
 #:kivy 1.2.0
 #:import metrics kivy.metrics
-#:import abspath os.path.abspath
 
 <TreeLabel>:
     on_touch_down:
@@ -158,7 +157,7 @@ Builder.load_string('''
                 height: '22dp'
                 text_size: self.size
                 padding_x: '-10dp'
-                text: abspath(root.path)
+                text: root.path
                 valign: 'middle'
             TabbedPanel:
                 id: tabbed_browser
@@ -473,6 +472,10 @@ class FileBrowser(BoxLayout):
         Clock.schedule_once(self._post_init)
 
     def _post_init(self, *largs):
+        if platform == 'win':
+            # Set the starting path to e.g.: D:
+            self.path = getcwd().split(sep,1)[0].upper() + sep
+
         self.ids.icon_view.bind(selection=partial(self._attr_callback, 'selection'),
                                 path=partial(self._attr_callback, 'path'),
                                 filters=partial(self._attr_callback, 'filters'),

--- a/__init__.py
+++ b/__init__.py
@@ -119,6 +119,8 @@ class FileBrowserIconView(IconView):
         # Remove appended '../' strings
         if(entry.path == u'..' + sep):
           self.path = sep.join(self.path.split(sep)[:-3]) + sep
+        else:
+          self.path = self.path + sep
 
 class FileBrowserListView(ListView):
     def open_entry(self, entry):
@@ -127,6 +129,8 @@ class FileBrowserListView(ListView):
         # Remove appended '../' strings
         if(entry.path == u'..' + sep):
           self.path = sep.join(self.path.split(sep)[:-3]) + sep
+        else:
+          self.path = self.path + sep
 
 Builder.load_string('''
 #:kivy 1.2.0
@@ -171,7 +175,7 @@ Builder.load_string('''
                 height: '22dp'
                 text_size: self.size
                 padding_x: '-10dp'
-                text: root.path
+                text: '' if len(root.path) < 2 else (root.path if root.path[-2] == ':' else root.path[:-1])
                 valign: 'middle'
             TabbedPanel:
                 id: tabbed_browser


### PR DESCRIPTION
Add 4 minor fixes that make the user experience a lot better:

on commit d955075 - On the `TextInput` when the user clicked on a file the full path would appear, but the normal is to expect only the `basename` of the file there. Now this field shows only the `basename` of the selected files. To recover the full path do `browser.path + browser.filename`

on commit a93865a - The variable path started as `\` on Windows, now it will correctly show the upper case partition letter followed by `:\`.

on commit 45b2082 - If the user was navigating on the path: `C:\users` and clicked on `..` the new path would to be: `C:\users\..` now the new path is: `C:\` (Note: *This only happened on Windows*)

on commit ad4e374 - Now the path variable will always end in `\` or  `/` so it is easier to work with `FileBrowser().path` without checking whether it ends with `sep` or not.

on commit 74898b2 - The bug that 45b2082 fix do not exist on Linux thus this fix to Windows became a bug on Linux platform. This commit fix that on Linux.

NOTE: **These commits have only been tested on Windows and Linux**

