### PR TITLE
Minor fixes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -17,7 +17,7 @@ To create a FileBrowser which prints the currently selected file as well as
 the current text in the filename field when 'Select' is pressed, with
 a shortcut to the Documents directory added to the favorites bar::
 
-    ffrom kivy.app import App
+    from kivy.app import App
     from os.path import sep, expanduser, isdir, dirname
 
     class TestApp(App):
@@ -35,10 +35,10 @@ a shortcut to the Documents directory added to the favorites bar::
             return browser
 
         def _fbrowser_canceled(self, instance):
-            print 'cancelled, Close self.'
+            print('cancelled, Close self.')
 
         def _fbrowser_success(self, instance):
-            print instance.selection
+            print(instance.selection)
 
     TestApp().run()
 
@@ -73,7 +73,7 @@ from kivy.lang import Builder
 from kivy.utils import platform
 from kivy.clock import Clock
 import string
-from os.path import sep, dirname, expanduser, isdir
+from os.path import sep, dirname, expanduser, isdir, basename
 from os import walk
 from functools import partial
 
@@ -196,8 +196,7 @@ Builder.load_string('''
         spacing: [5]
         TextInput:
             id: file_text
-            text: (root.selection and (root._shorten_filenames(\
-            root.selection) if root.multiselect else root.selection[0])) or ''
+            text: (root.selection and (root._shorten_filenames(root.selection))) or ''
             hint_text: 'Filename'
             multiline: False
         Button:
@@ -495,11 +494,11 @@ class FileBrowser(BoxLayout):
         if not len(filenames):
             return ''
         elif len(filenames) == 1:
-            return filenames[0]
+            return basename(filenames[0])
         elif len(filenames) == 2:
-            return filenames[0] + ', ' + filenames[1]
+            return basename(filenames[0]) + ', ' + basename(filenames[1])
         else:
-            return filenames[0] + ', _..._, ' + filenames[-1]
+            return basename(filenames[0]) + ', _..._, ' + basename(filenames[-1])
 
     def _attr_callback(self, attr, obj, value):
         setattr(self, attr, getattr(obj, attr))

--- a/__init__.py
+++ b/__init__.py
@@ -156,7 +156,7 @@ Builder.load_string('''
                 size_hint_y: None
                 height: '22dp'
                 text_size: self.size
-                padding_x: '-10dp'
+                padding_x: 10
                 text: root.path
                 valign: 'middle'
             TabbedPanel:

--- a/__init__.py
+++ b/__init__.py
@@ -74,7 +74,7 @@ from kivy.utils import platform
 from kivy.clock import Clock
 import string
 from os.path import sep, dirname, expanduser, isdir, basename
-from os import walk
+from os import walk, getcwd
 from functools import partial
 
 if platform == 'win':
@@ -117,7 +117,6 @@ class FileBrowserIconView(IconView):
 Builder.load_string('''
 #:kivy 1.2.0
 #:import metrics kivy.metrics
-#:import abspath os.path.abspath
 
 <TreeLabel>:
     on_touch_down:
@@ -158,7 +157,7 @@ Builder.load_string('''
                 height: '22dp'
                 text_size: self.size
                 padding_x: '-10dp'
-                text: abspath(root.path)
+                text: root.path
                 valign: 'middle'
             TabbedPanel:
                 id: tabbed_browser
@@ -473,6 +472,10 @@ class FileBrowser(BoxLayout):
         Clock.schedule_once(self._post_init)
 
     def _post_init(self, *largs):
+        if platform == 'win':
+            # Set the starting path to e.g.: D:
+            self.path = getcwd().split(sep,1)[0].upper() + sep
+
         self.ids.icon_view.bind(selection=partial(self._attr_callback, 'selection'),
                                 path=partial(self._attr_callback, 'path'),
                                 filters=partial(self._attr_callback, 'filters'),


### PR DESCRIPTION
Three minor fixes:
d955075 - When the user click on a file the internal variable `FileBrowser().filename` is set to the full path of that file and the TextInput field shows that value. This behavior is not the expected behavior. This commit fixes it by setting `FileBrowser().filename` to the `basename()` of the file. If the programmer wants the full path he can either concatenate `FileBrowser().path` with `FileBrowser().filename` or read `FileBrowser().selection` which still contain the full path of all selected files.

a93865a - On Windows the starting path used to be set to `\` which is confusing for Windows users, now if the program is being executed on the drive `D` the current working directory will be set to `D:\` instead of `\`.

835e73f - `padding_x` of the address `Label` was set to `-10` since old Kivy versions had a bug that used to read the negative value of `padding_x`. The current Kivy version has it fixed so `padding_x` = `-10` results in the address bar going outside its parent widget. The fix was to set it to `10` instead.