### PR TITLE
Avoid errors if callback filters are present

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -211,7 +211,7 @@ Builder.load_string('''
             on_text_validate:
                 root.filters = self.text.split(',') if self.text else []
             multiline: False
-            text: ','.join(root.filters)
+            text: ','.join([filt for filt in root.filters if isinstance(filt, str)])
         Button:
             id: cancel_button
             size_hint_x: None


### PR DESCRIPTION
As described in the [filter documentation](http://kivy.org/docs/api-kivy.uix.filechooser.html#kivy.uix.filechooser.FileChooserController.filters), a filter can be a callable.  This causes errors in the [TextInput](https://github.com/kivy-garden/garden.filebrowser/blob/master/__init__.py#L214) and crashes.

Currently only the text property assignment is addressed.  If text is entered, the `on_text_validate` event will remove any previously existing filters in the list.