### PR TITLE
checking exitstence of drive

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -111,7 +111,8 @@ def get_drives():
                 drive = letter + u':'
                 res = GetVolumeInformationW(drive + sep, name, 64, None,
                                             None, None, None, 0)
-                drives.append((drive, name.value))
+                if isdir(drive):
+                    drives.append((drive, name.value))
             bitmask >>= 1
     elif platform == 'linux':
         drives.append((sep, sep))


### PR DESCRIPTION
Checking the exitstence of drive to avoid phantom-drives.
Drives like USB-Drive showed up, even if there was nothing plugged in.
